### PR TITLE
Add ocs_update.php to be able to upgrade large ocsinventory databases

### DIFF
--- a/tools/ocs_update.php
+++ b/tools/ocs_update.php
@@ -1,0 +1,10 @@
+<?php
+
+include('../../../inc/includes.php');
+
+$plug = new Plugin;
+
+if( $plug->getFromDBbyDir('ocsinventoryng') && in_array( $plug->fields['state'], [Plugin::NOTUPDATED, Plugin::NOTINSTALLED] ) ) {
+   $plug->install( $plug->getID() );
+}
+


### PR DESCRIPTION
Use: in tools directory, just call:
`php -f ocs_update.php`
and when upgrade is OK, in GLPI, enable the plugin

