### PR TITLE
Correct Accountinfo import bug

### DIFF
--- a/inc/ocsdbclient.class.php
+++ b/inc/ocsdbclient.class.php
@@ -101,7 +101,7 @@ class PluginOcsinventoryngOcsDbClient extends PluginOcsinventoryngOcsClient
                   if (preg_match('/fields_\d+/', $column, $matches)) {
                      $colnumb = explode("fields_", $matches['0']);
 
-                     if (TableExists("accountinfo_config")) {
+                     if (self::OcsTableExists("accountinfo_config")) {
                         $col            = $colnumb['1'];
                         $query          = "SELECT ID,NAME FROM accountinfo_config WHERE ID = '" . $col . "'";
                         $requestcolname = $this->db->query($query);
@@ -242,7 +242,7 @@ class PluginOcsinventoryngOcsDbClient extends PluginOcsinventoryngOcsClient
                      if (preg_match('/fields_\d+/', $column, $matches)) {
                         $colnumb = explode("fields_", $matches['0']);
 
-                        if (TableExists("accountinfo_config")) {
+                        if (self::OcsTableExists("accountinfo_config")) {
                            $col = $colnumb['1'];
                            $query = "SELECT ID,NAME FROM accountinfo_config WHERE ID = '" . $col . "'";
                            $requestcolname = $this->db->query($query);
@@ -1294,22 +1294,6 @@ class PluginOcsinventoryngOcsDbClient extends PluginOcsinventoryngOcsClient
          $columns = $this->db->query($query);
          while ($column = $this->db->fetch_assoc($columns)) {
             $res[$column['Field']] = $column['Field'];
-         }
-         if (TableExists($table . "_config")) {
-            $query = "SELECT * FROM  `accountinfo_config` ";
-            $confs = $this->db->query($query);
-            while ($conf = $this->db->fetch_assoc($confs)) {
-               $key = "fields_" . $conf["ID"];
-               if (array_key_exists($key, $res)) {
-                  if ($conf["TYPE"]) {
-                     $res[$key] = array("NOM"    => $conf['COMMENT'],
-                                        "PREFIX" => "ACCOUNT_INFO_" . $conf["NAME"] . "_",
-                     );
-                  } else {
-                     $res[$key] = $conf['COMMENT'];
-                  }
-               }
-            }
          }
       } elseif ($table == 'hardware') {
          $res['DEVICEID'] = 'DEVICEID';


### PR DESCRIPTION
Hi,

There is a bug on the plugin, account info data wasn't imported properly. In case of specific accountinfo type (Select in my case.) the ID of the select was imported instead of the Name.
For example: If you link the Glpi Location to an account info which is a select, the account info id was imported as the Location, not the Name.

There was a little mistake in the code, sometime the "TableExists" function was used instead of the "OcsTableExists" for checking the existence of OCS Tables.

I changed 2 of theses call and remove an if statement which was never called in the plugin.

Regards,
Gilles Dubois.
