### PR TITLE
Bitlocker import : php notice on import

### DIFF
--- a/inc/bitlockerstatus.class.php
+++ b/inc/bitlockerstatus.class.php
@@ -82,7 +82,9 @@ class PluginOcsinventoryngBitlockerstatus extends CommonDBChild {
                $statusText = isset($bitlocker["CONVERSIONSTATUS"]) ? $bitlocker["CONVERSIONSTATUS"] : '';
                $status = [
                   'FullyDecrypted' => 0,
+                  'DISABLED' => 0,
                   'FullyEncrypted' => 1,
+                  'ENABLED' => 1,
                   'EncryptionInProgress' => 2,
                   'DecryptionInProgress' => 2,
                   'EncryptionPaused' => 2,

--- a/inc/winuser.class.php
+++ b/inc/winuser.class.php
@@ -86,7 +86,7 @@ class PluginOcsinventoryngWinuser extends CommonDBChild {
             $input["name"]        = $wuser["NAME"];
             $input["type"]        = (isset($wuser["TYPE"]) ? $wuser["TYPE"] : '');
             $input["description"] = (isset($wuser["TYPE"]) ? $wuser["DESCRIPTION"] : '');
-            $input["disabled"]    = (isset($wuser["TYPE"]) ? $wuser["DISABLED"] : '');
+            $input["disabled"]    = (isset($wuser["TYPE"]) ? $wuser["STATUS"] : '');
             $input["sid"]         = (isset($wuser["TYPE"]) ? $wuser["SID"] : '');
 
             $winusers->add($input, ['disable_unicity_check' => true], $install_history);
@@ -196,7 +196,7 @@ class PluginOcsinventoryngWinuser extends CommonDBChild {
             $header = "<tr><th>" . __('Name') . "</th>";
             $header .= "<th>" . __('Type') . "</th>";
             $header .= "<th>" . __('Description') . "</th>";
-            $header .= "<th>" . __('Disabled', 'ocsinventoryng') . "</th>";
+            $header .= "<th>" . __('Status', 'ocsinventoryng') . "</th>";
             $header .= "<th>" . __('SID', 'ocsinventoryng') . "</th>";
             $header .= "</tr>";
             echo $header;


### PR DESCRIPTION
Hi,

When I import my computer with Bitlocker import activated, there was a PHP Notice in apache logs with OCS 2.8.
I fixed this issue by adding 'ENABLED' and 'DISABLED' in the status list.

I remain available if you need anything else.

Regards,
Rudy LAURENT