### PR TITLE
Winupdate import : Adapt database model to the new plugin version

### DIFF
--- a/inc/bitlockerstatus.class.php
+++ b/inc/bitlockerstatus.class.php
@@ -82,7 +82,9 @@ class PluginOcsinventoryngBitlockerstatus extends CommonDBChild {
                $statusText = isset($bitlocker["CONVERSIONSTATUS"]) ? $bitlocker["CONVERSIONSTATUS"] : '';
                $status = [
                   'FullyDecrypted' => 0,
+                  'DISABLED' => 0,
                   'FullyEncrypted' => 1,
+                  'ENABLED' => 1,
                   'EncryptionInProgress' => 2,
                   'DecryptionInProgress' => 2,
                   'EncryptionPaused' => 2,

--- a/inc/winupdate.class.php
+++ b/inc/winupdate.class.php
@@ -78,14 +78,16 @@ class PluginOcsinventoryngWinupdate extends CommonDBChild {
       //update data
       if (!empty($ocsComputer)) {
 
-         $wupdate                      = Toolbox::clean_cross_side_scripting_deep(Toolbox::addslashes_deep($ocsComputer));
-         $input                        = [];
-         $input["computers_id"]        = $computers_id;
-         $input["auoptions"]           = $wupdate["AUOPTIONS"];
-         $input["scheduleinstalldate"] = (empty($wupdate["SCHEDULEDINSTALLDATE"]) ? 'NULL' : $wupdate["SCHEDULEDINSTALLDATE"]);
-         $input["lastsuccesstime"]     = $wupdate["LASTSUCCESSTIME"];
-         $input["detectsuccesstime"]   = $wupdate["DETECTSUCCESSTIME"];
-         $input["downloadsuccesstime"] = $wupdate["DOWNLOADSUCCESSTIME"];
+         $wupdate               = Toolbox::clean_cross_side_scripting_deep(Toolbox::addslashes_deep($ocsComputer));
+         $input                 = [];
+         $input["computers_id"] = $computers_id;
+         $input["kb"]           = $wupdate["KB"];
+         $input["title"]        = (empty($wupdate["TITLE"]) ? 'NULL' : $wupdate["TITLE"]);
+         $input["date"]         = $wupdate["DATE"];
+         $input["operation"]    = $wupdate["OPERATION"];
+         $input["status"]       = $wupdate["STATUS"];
+         $input["supportlink"]  = $wupdate["SUPPORTLINK"];
+         $input["description"]  = $wupdate["DESCRIPTION"];
 
          $CompWupdate = new self();
          $CompWupdate->add($input, ['disable_unicity_check' => true], $install_history);
@@ -191,11 +193,13 @@ class PluginOcsinventoryngWinupdate extends CommonDBChild {
 
          if ($result->numrows() != 0) {
 
-            $header = "<tr><th>" . __('AU Options', 'ocsinventoryng') . "</th>";
-            $header .= "<th>" . __('Schedule Install Date', 'ocsinventoryng') . "</th>";
-            $header .= "<th>" . __('Last Success Time', 'ocsinventoryng') . "</th>";
-            $header .= "<th>" . __('Detect Success Time', 'ocsinventoryng') . "</th>";
-            $header .= "<th>" . __('Download Success Time', 'ocsinventoryng') . "</th>";
+            $header = "<tr><th>" . __('KB', 'ocsinventoryng') . "</th>";
+            $header .= "<th>" . __('Title', 'ocsinventoryng') . "</th>";
+            $header .= "<th>" . __('Date', 'ocsinventoryng') . "</th>";
+            $header .= "<th>" . __('Operation', 'ocsinventoryng') . "</th>";
+            $header .= "<th>" . __('Status', 'ocsinventoryng') . "</th>";
+            $header .= "<th>" . __('Support link', 'ocsinventoryng') . "</th>";
+            $header .= "<th>" . __('Description', 'ocsinventoryng') . "</th>";
             $header .= "</tr>";
             echo $header;
 
@@ -207,32 +211,13 @@ class PluginOcsinventoryngWinupdate extends CommonDBChild {
 
             foreach ($result as $data) {
                echo "<tr class='tab_bg_2'>";
-               echo "<td>" . self::getAuoptionsName($data['auoptions']) . "</td>";
-               
-               if (DateTime::createFromFormat('Y-m-d H:i:s', $data['scheduleinstalldate']) !== FALSE 
-                  && $data['scheduleinstalldate'] != "0000-00-00 00:00:00") {
-                  echo "<td>" . Html::convDateTime($data['scheduleinstalldate']) . "</td>";
-               } else {
-                  echo "<td>" . __('Automatic') . "</td>";
-               }
-               if (DateTime::createFromFormat('Y-m-d H:i:s', $data['lastsuccesstime']) !== FALSE 
-                  && $data['lastsuccesstime'] != "0000-00-00 00:00:00") {
-                  echo "<td>" . Html::convDateTime($data['lastsuccesstime']) . "</td>";
-               } else {
-                  echo "<td>" . __('Automatic') . "</td>";
-               }
-               if (DateTime::createFromFormat('Y-m-d H:i:s', $data['detectsuccesstime']) !== FALSE 
-                  && $data['detectsuccesstime'] != "0000-00-00 00:00:00") {
-                  echo "<td>" . Html::convDateTime($data['detectsuccesstime']) . "</td>";
-               } else {
-                  echo "<td>" . __('Automatic') . "</td>";
-               }
-               if (DateTime::createFromFormat('Y-m-d H:i:s', $data['downloadsuccesstime']) !== FALSE 
-                  && $data['downloadsuccesstime'] != "0000-00-00 00:00:00") {
-                  echo "<td>" . Html::convDateTime($data['downloadsuccesstime']) . "</td>";
-               } else {
-                  echo "<td>" . __('Automatic') . "</td>";
-               }
+               echo "<td>" . $data['kb'] . "</td>";
+               echo "<td>" . $data['title'] . "</td>";
+               echo "<td>" . $data['date'] . "</td>";
+               echo "<td>" . $data['operation'] . "</td>";
+               echo "<td>" . $data['status'] . "</td>";
+               echo "<td>" . $data['supportlink'] . "</td>";
+               echo "<td>" . $data['description'] . "</td>";
                echo "</tr>";
                Session::addToNavigateListItems(__CLASS__, $data['id']);
             }

--- a/inc/winuser.class.php
+++ b/inc/winuser.class.php
@@ -86,7 +86,7 @@ class PluginOcsinventoryngWinuser extends CommonDBChild {
             $input["name"]        = $wuser["NAME"];
             $input["type"]        = (isset($wuser["TYPE"]) ? $wuser["TYPE"] : '');
             $input["description"] = (isset($wuser["TYPE"]) ? $wuser["DESCRIPTION"] : '');
-            $input["disabled"]    = (isset($wuser["TYPE"]) ? $wuser["DISABLED"] : '');
+            $input["disabled"]    = (isset($wuser["TYPE"]) ? $wuser["STATUS"] : '');
             $input["sid"]         = (isset($wuser["TYPE"]) ? $wuser["SID"] : '');
 
             $winusers->add($input, ['disable_unicity_check' => true], $install_history);
@@ -196,7 +196,7 @@ class PluginOcsinventoryngWinuser extends CommonDBChild {
             $header = "<tr><th>" . __('Name') . "</th>";
             $header .= "<th>" . __('Type') . "</th>";
             $header .= "<th>" . __('Description') . "</th>";
-            $header .= "<th>" . __('Disabled', 'ocsinventoryng') . "</th>";
+            $header .= "<th>" . __('Status', 'ocsinventoryng') . "</th>";
             $header .= "<th>" . __('SID', 'ocsinventoryng') . "</th>";
             $header .= "</tr>";
             echo $header;

--- a/install/mysql/1.7.1-empty.sql
+++ b/install/mysql/1.7.1-empty.sql
@@ -200,11 +200,13 @@ DROP TABLE IF EXISTS `glpi_plugin_ocsinventoryng_winupdates`;
 CREATE TABLE `glpi_plugin_ocsinventoryng_winupdates` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `computers_id` int(11) NOT NULL DEFAULT '0',
-  `auoptions` int(11) NOT NULL DEFAULT '0',
-  `scheduleinstalldate` timestamp NULL DEFAULT NULL,
-  `lastsuccesstime` timestamp NULL DEFAULT NULL,
-  `detectsuccesstime` timestamp NULL DEFAULT NULL,
-  `downloadsuccesstime` timestamp NULL DEFAULT NULL,
+  `kb` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `date` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `operation` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `status` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `supportlink` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `description` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `computers_id` (`computers_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;


### PR DESCRIPTION
Hi,

When I import my computer with Winupdate import activated, the winupdate data were not imported.
There is a new version of Winupdate and the data in DB changed.

In this PR, I updated the files with the new data but I didn't implemented the migration.


You will find below the new table structure : 

```
DROP TABLE IF EXISTS `glpi_plugin_ocsinventoryng_winupdates`;
CREATE TABLE `glpi_plugin_ocsinventoryng_winupdates` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `computers_id` int(11) NOT NULL DEFAULT '0',
  `kb` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `date` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `operation` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `status` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `supportlink` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `description` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `computers_id` (`computers_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
```

I remain available if you need anything else.

Regards,
Rudy LAURENT