### PR TITLE
Fix crash with PDF plugin virtual objects lacking getID()

### DIFF
--- a/src/Ocslink.php
+++ b/src/Ocslink.php
@@ -1006,26 +1006,34 @@ class Ocslink extends CommonDBTM
      *
      * @return int
      */
-    public static function getOCSServerForItem(CommonGLPI $item)
-    {
-        global $DB;
-        $dbu = new DbUtils();
-        $query = "SELECT *
-                FROM `glpi_plugin_ocsinventoryng_ocslinks`
-                WHERE `computers_id` = " . $item->getID() . " " .
-                 $dbu->getEntitiesRestrictRequest("AND", "glpi_plugin_ocsinventoryng_ocslinks");
+	public static function getOCSServerForItem(CommonGLPI $item)
+	{
+		global $DB;
 
-        $result = $DB->doQuery($query);
-        if ($DB->numrows($result) > 0) {
-            $data = $DB->fetchAssoc($result);
+		// Evita errores con objetos virtuales del plugin PDF
+		if (!method_exists($item, 'getID')) {
+			return 0;
+		}
 
-            if (count($data)) {
-                return $data['plugin_ocsinventoryng_ocsservers_id'];
-            }
+		$dbu = new DbUtils();
 
-            return false;
-        }
-    }
+		$query = "SELECT *
+				FROM `glpi_plugin_ocsinventoryng_ocslinks`
+				WHERE `computers_id` = " . $item->getID() . " " .
+				 $dbu->getEntitiesRestrictRequest("AND", "glpi_plugin_ocsinventoryng_ocslinks");
+
+		$result = $DB->doQuery($query);
+
+		if ($DB->numrows($result) > 0) {
+			$data = $DB->fetchAssoc($result);
+
+			if (count($data)) {
+				return $data['plugin_ocsinventoryng_ocsservers_id'];
+			}
+		}
+
+		return 0;
+	}
 
     /**
      * Make the item link between glpi and ocs.


### PR DESCRIPTION
The PDF plugin may pass virtual `CommonGLPI` objects such as `PluginPdfComputer` to:

```php id="6d7bx9"
Ocslink::getOCSServerForItem()
```

Those objects do not implement `getID()`, causing:

```text id="3p98ks"
Attempted to call an undefined method named "getID"
```

This patch adds a defensive `method_exists()` validation before calling `getID()`.

Result:

* prevents fatal crash during PDF generation
* keeps compatibility with OCS synchronization
* improves compatibility with virtual/helper plugin objects
